### PR TITLE
Add Filter for incoming and outgoing delivery

### DIFF
--- a/backend/Controllers/OrderController.cs
+++ b/backend/Controllers/OrderController.cs
@@ -29,25 +29,25 @@ public class OrderController : ControllerBase
 		return Ok(new { message = "Get orders successfully", orders });
 	}
 
-	[HttpGet]
-	[VerifyToken]
-	public async Task<ActionResult<Response<DataPagination<PublicOrderInfo>>>> FilterAsync(int pageNumber, OrderState? status, string? category, DateTime? startDate, DateTime? endDate)
-	{
-		DataPagination<PublicOrderInfo> orders = await _orderService.FilterAsync(pageNumber, status, category, startDate?.ToUniversalTime(), endDate?.ToUniversalTime());
-		return Ok(new Response<DataPagination<PublicOrderInfo>>("Get orders successfully", orders));
-	}
-
 	[HttpGet("{id}")]
 	public async Task<IActionResult> GetAsync(Guid id)
 	{
-		List<OrderHistory> orderHistory = await _orderService.GetAsyncById(id) ?? throw new AppException(HttpStatusCode.NotFound, "Order not found");
+		List<OrderHistory> orderHistory = await _orderService.GetAsync(id) ?? throw new AppException(HttpStatusCode.NotFound, "Order not found");
 		return Ok(new { message = "Get order history successfully", orderHistory });
+	}
+
+	[HttpGet] 
+	[VerifyToken]
+	public async Task<IActionResult> FilterOrderAsync( int pageNumber, string? status, string? category, DateTime? startDate, DateTime? endDate) 
+	{
+		var orders = await _orderService.FiltOrderAsync(status, category, startDate?.ToUniversalTime(), endDate?.ToUniversalTime(), pageNumber);
+		return Ok(orders);
 	}
 
 	[HttpPut("{id}")]
 	[VerifyToken]
 	[VerifyOwner]
-	[VerifyRole(Role.TRANSACION_STAFF, Role.GATHERING_STAFF)]
+	[VerifyRole(new Role[] { Role.TRANSACION_STAFF, Role.GATHERING_STAFF })]
 	public async Task<IActionResult> UpdateAsync(Guid id, UpdateOrderModel model)
 	{
 		await _orderService.UpdateAsync(id, model);
@@ -56,55 +56,55 @@ public class OrderController : ControllerBase
 
 	[HttpPost]
 	[VerifyToken]
-	[VerifyPointAndAdmin]
+	//[VerifyRole(new Role[] {Role.TRANSACION_STAFF, Role.GATHERING_STAFF})]
 	public async Task<IActionResult> CreateAsync(CreateOrderModel model)
 	{
 		Order order = _mapper.Map<Order>(model);
-		await _orderService.CreateAsync((User?)HttpContext.Items["user"]!, order);
+		await _orderService.CreateAsync((User?)HttpContext.Items["user"] ,order);
 		return Ok(new { message = "Create order successfully!", order });
 	}
 
 	[HttpGet("{id}")]
 	[VerifyToken]
 	[VerifyOwner]
-	[VerifyRole(Role.TRANSACION_STAFF, Role.GATHERING_STAFF)]
-	public async Task<ActionResult<Response<DataPagination<PublicOrderInfo>>>> GetIncomingOrdersAsync(int pageNumber)
+	[VerifyRole(new Role[] {Role.TRANSACION_STAFF, Role.GATHERING_STAFF})]
+	public async Task<IActionResult> GetIncomingOrdersAsync(string? province, string? district, DateTime? startDate, DateTime? endDate ,int pageNumber) 
 	{
 		User? user = (User?)HttpContext.Items["user"];
-		DataPagination<PublicOrderInfo> ordersIncoming = await _orderService.GetIncomingOrdersAsync(user!, pageNumber);
-		return Ok(new Response<DataPagination<PublicOrderInfo>>("Get incoming orders successfully!", ordersIncoming));
-	}
+		var ordersIncoming = await _orderService.GetIncomingOrdersAsync(user, province, district, startDate, endDate, pageNumber);
+		return Ok(ordersIncoming);
+	} 
 
 	[HttpPut("{id}")]
 	[VerifyToken]
 	[VerifyOwner]
-	[VerifyRole(Role.TRANSACION_STAFF, Role.GATHERING_STAFF)]
-	public async Task<IActionResult> ConfirmIncomingOrdersAsync(List<ConfirmIncomingOrderModel> orders)
+	[VerifyRole(new Role[] {Role.TRANSACION_STAFF, Role.GATHERING_STAFF})]
+	public async Task<IActionResult> ConfirmIncomingOrdersAsync(List<ConfirmIncomingOrderModel> orders) 
 	{
 		User? user = (User?)HttpContext.Items["user"];
-		var result = await _orderService.ConfirmIncomingOrdersAsync(user!, orders);
+		var result = await _orderService.ConfirmIncomingOrdersAsync(user, orders);
 		return Ok(result);
-	}
+	} 	
 
 	[HttpGet("{id}")]
 	[VerifyToken]
 	[VerifyOwner]
-	[VerifyRole(Role.TRANSACION_STAFF, Role.GATHERING_STAFF)]
-	public async Task<ActionResult<Response<DataPagination<PublicOrderInfo>>>> GetOutgoingOrdersAsync(int pageNumber)
+	[VerifyRole(new Role[] {Role.TRANSACION_STAFF, Role.GATHERING_STAFF})]
+	public async Task<IActionResult> GetOutgoingOrdersAsync(string? province, string? district, int pageNumber) 
 	{
 		User? user = (User?)HttpContext.Items["user"];
-		DataPagination<PublicOrderInfo> ordersOutgoing = await _orderService.GetOutgoingOrdersAsync(user!, pageNumber);
-		return Ok(new Response<DataPagination<PublicOrderInfo>>("Get outgoing orders successfully!", ordersOutgoing));
-	}
+		var ordersIncoming = await _orderService.GetOutgoingOrdersAsync(user, province, district, pageNumber);
+		return Ok(ordersIncoming);
+	} 
 
 	[HttpPost("{id}")]
 	[VerifyToken]
 	[VerifyOwner]
-	[VerifyRole(Role.TRANSACION_STAFF, Role.GATHERING_STAFF)]
-	public async Task<IActionResult> ForwardOrdersAsync(List<Guid> orders)
+	[VerifyRole(new Role[] {Role.TRANSACION_STAFF, Role.GATHERING_STAFF})]
+	public async Task<IActionResult> ForwardOrdersAsync(List<Guid> orders) 
 	{
 		User? user = (User?)HttpContext.Items["user"];
-		var result = await _orderService.ForwardOrdersAsync(user!, orders);
+		var result = await _orderService.ForwardOrdersAsync(user, orders);
 		return Ok(result);
-	}
+	} 
 }

--- a/backend/Enums/PointType.cs
+++ b/backend/Enums/PointType.cs
@@ -1,6 +1,6 @@
 namespace MagicPostApi.Enums;
 public enum PointType
 {
-	TRANSACTION_POINT = 0,
-	GATHERING_POINT = 1,
+	TRANSACTION_POINT = 1,
+	GATHERING_POINT = 0,
 }

--- a/backend/Models/Delivery.cs
+++ b/backend/Models/Delivery.cs
@@ -41,8 +41,11 @@ public class Delivery : Model
 			history.Add(new DeliveryHistory() { OrderId = OrderId, Point = ToPoint.ToString(), Type = "outgoing", Status = "confirmed", Reason = "", Time = ReceiveTime });
 			history.Add(new DeliveryHistory() { OrderId = OrderId, Point = FromPoint.ToString(), Type = "incoming", Status = "confirmed", Reason = "", Time = ReceiveTime });
 		}
-
-
+		else 
+		{
+			history.Add(new DeliveryHistory(){OrderId = OrderId, Point = ToPoint.ToString(),Type = "outgoing", Status = "confirmed", Reason = "", Time = ReceiveTime});
+			history.Add(new DeliveryHistory(){OrderId = OrderId, Point = FromPoint.ToString(),Type = "incoming", Status = "confirmed", Reason = "", Time = ReceiveTime});
+		} 
 		return history;
 	}
 

--- a/backend/Program.cs
+++ b/backend/Program.cs
@@ -66,9 +66,9 @@ if (app.Environment.IsDevelopment())
 	// Get db context for development initialization
 	var db = scope.ServiceProvider.GetRequiredService<WebAPIDataContext>();
 	// Delete database
-	db.Database.EnsureDeleted();
-	// Create database again to sync schemas update
-	db.Database.EnsureCreated();
+	// db.Database.EnsureDeleted();
+	// // Create database again to sync schemas update
+	// db.Database.EnsureCreated();
 }
 
 {


### PR DESCRIPTION
add filter for incoming and outgoing. Incoming orders are filted by province and district of sender's point address, and delivery's create date, and outgoing orders are filted by province and district of the nextPoint. 